### PR TITLE
feat: add TypeScript definitions and paginated room message history

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ console.log(result)
 // }
 ```
 
+Page `1` returns the most recent messages.
+Message history is stored in memory per process, so pagination works for single-process deployments only.
+
 ### Notifications
 
 ```javascript

--- a/src/messages.js
+++ b/src/messages.js
@@ -8,6 +8,8 @@ const MESSAGE_TYPES = {
 }
 
 const roomMessages = new Map()
+const MAX_MESSAGES_PER_ROOM = 1000
+const MAX_PAGE_SIZE = 100
 
 function sendMessage(roomId, message) {
   if (!roomId) throw new Error(
@@ -36,7 +38,11 @@ function sendMessage(roomId, message) {
   if (!roomMessages.has(roomId)) {
     roomMessages.set(roomId, [])
   }
-  roomMessages.get(roomId).push(payload)
+  const messages = roomMessages.get(roomId)
+  messages.push(payload)
+  if (messages.length > MAX_MESSAGES_PER_ROOM) {
+    messages.splice(0, messages.length - MAX_MESSAGES_PER_ROOM)
+  }
   getIO().to(roomId).emit('message:new', payload)
   return payload
 }
@@ -47,6 +53,11 @@ function editMessage(roomId, messageId, newContent) {
   if (message) {
     message.content = newContent
     message.editedAt = new Date()
+  } else {
+    console.warn(
+      `[quick-socket] editMessage warning: message "${messageId}" was not found in memory for room "${roomId}". ` +
+      'The socket event was emitted, but the in-memory message history was not updated.'
+    )
   }
   getIO().to(roomId).emit('message:edited', {
     messageId,
@@ -71,7 +82,7 @@ function sendTyping(roomId, userId, isTyping) {
 function getRoomMessages(roomId, page = 1, limit = 20) {
   const messages = roomMessages.get(roomId) || []
   const currentPage = Math.max(Number(page) || 1, 1)
-  const pageSize = Math.max(Number(limit) || 20, 1)
+  const pageSize = Math.min(Math.max(Number(limit) || 20, 1), MAX_PAGE_SIZE)
   const total = messages.length
   const totalPages = total === 0 ? 0 : Math.ceil(total / pageSize)
   const end = total - (currentPage - 1) * pageSize

--- a/test/test.js
+++ b/test/test.js
@@ -175,6 +175,32 @@ async function runTests() {
   const messagesAfterClose = quickSocket.getRoomMessages('room-1', 1, 20)
   log('closeRoom clears stored room messages', messagesAfterClose.total === 0)
 
+  // ── Validation Tests ──
+  let validationPassed = true
+
+  try {
+    quickSocket.sendMessage(undefined, {})
+    validationPassed = false
+  } catch (err) {
+    if (!err.message.includes('requires a roomId')) validationPassed = false
+  }
+
+  try {
+    quickSocket.sendMessage('room-1', { senderId: 'u1', content: '' })
+    validationPassed = false
+  } catch (err) {
+    if (!err.message.includes('cannot be empty')) validationPassed = false
+  }
+
+  try {
+    quickSocket.createRoom('')
+    validationPassed = false
+  } catch (err) {
+    if (!err.message.includes('non-empty string roomId')) validationPassed = false
+  }
+
+  log('validation throws correct errors for invalid inputs', validationPassed)
+
   // ── Test 14: MESSAGE_TYPES constants ──
   log('MESSAGE_TYPES.TEXT is "text"', quickSocket.MESSAGE_TYPES.TEXT === 'text')
   log('MESSAGE_TYPES.IMAGE is "image"', quickSocket.MESSAGE_TYPES.IMAGE === 'image')
@@ -212,7 +238,7 @@ async function runTests() {
     const next = (err) => {
       log(
         'authMiddleware missing token returns error',
-        err instanceof Error && err.message === 'No token provided'
+        err instanceof Error && err.message.includes('Authentication failed: no token found')
       )
       resolve()
     }
@@ -230,7 +256,7 @@ async function runTests() {
     const next = (err) => {
       log(
         'authMiddleware invalid token returns error',
-        err instanceof Error && err.message === 'Authentication failed'
+        err instanceof Error && err.message.includes('Authentication failed: the authFn you provided threw an error')
       )
       resolve()
     }
@@ -246,7 +272,7 @@ async function runTests() {
     const next = (err) => {
       log(
         'authMiddleware missing auth object returns error',
-        err instanceof Error && err.message === 'No token provided'
+        err instanceof Error && err.message.includes('Authentication failed: no token found')
       )
       resolve()
     }


### PR DESCRIPTION
## Summary
- add `src/index.d.ts` so TypeScript users get types for the public API
- add in-memory room message storage with `getRoomMessages(roomId, page, limit)`
- return paginated room message history and clear it on `closeRoom()`
- restore validation tests and align test expectations with current auth error messages
- document TypeScript support, pagination behavior, and single-process limitation in the README

## Details
- `sendMessage()` now stores messages in memory per room
- `getRoomMessages()` returns paginated results, where page `1` is the most recent messages
- pagination is capped to a reasonable page size and room history is capped in memory to avoid unbounded growth
- `editMessage()` now warns if the target message is not present in the in-memory store
- package metadata now points to `src/index.d.ts` via the `types` field

## Why
This improves developer experience for TypeScript consumers and adds a practical way to load older chat messages without fetching the full room history at once.

## Notes
- room message pagination currently uses in-memory storage, so it is intended for single-process deployments
- verified with `npm test` (`34 passed, 0 failed`)