### PR TITLE
feat: add presence, rate limiting, and reconnect recovery

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,6 +3,8 @@ import type { Server as SocketIOServer, Socket } from 'socket.io'
 
 export interface InitOptions {
   cors?: string
+  pingInterval?: number
+  pingTimeout?: number
 }
 
 export interface JoinRoomMeta {
@@ -91,3 +93,50 @@ export function getRoomMessages(roomId: string, page?: number, limit?: number): 
 export function markDelivered(roomId: string, messageId: string, userId: string): void
 export function markRead(roomId: string, messageId: string, userId: string): void
 export function markAllRead(roomId: string, userId: string): void
+
+// Presence
+export type PresenceStatus = 'online' | 'away' | 'offline'
+
+export interface PresenceInfo {
+  status: PresenceStatus
+  lastSeen: Date | null
+  meta: Record<string, any>
+}
+
+export interface RoomPresence {
+  [userId: string]: PresenceInfo
+}
+
+export const PRESENCE_STATUS: {
+  readonly ONLINE: 'online'
+  readonly AWAY: 'away'
+  readonly OFFLINE: 'offline'
+}
+
+export function trackPresence(socket: Socket, userId: string): void
+export function setPresence(userId: string, status: PresenceStatus, meta?: Record<string, any>): void
+export function getPresence(userId: string): PresenceInfo
+export function getRoomPresence(roomId: string): RoomPresence
+
+// Rate Limiting
+export interface RateLimitOptions {
+  limit?: number
+  windowMs?: number
+  events?: string[]
+  onLimitReached?: (socket: Socket, packet: any[]) => void
+}
+
+export function createRateLimiter(options?: RateLimitOptions): (socket: Socket, next: (err?: Error) => void) => void
+
+// Reconnect Recovery
+export interface RejoinOptions {
+  since?: string | Date
+}
+
+export interface RejoinResult {
+  rooms: string[]
+  missedMessages: Record<string, MessagePayload[]>
+}
+
+export function rejoinRooms(socket: Socket, userId: string, options?: RejoinOptions): RejoinResult
+export function getUserRooms(userId: string): string[]

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,9 @@ const { notifyUser, broadcast, notifyRoom } = require('./notifications')
 const { createRoom, joinRoom, leaveRoom, getRoomParticipants, closeRoom } = require('./rooms')
 const { sendMessage, editMessage, deleteMessage, sendTyping, getRoomMessages, MESSAGE_TYPES } = require('./messages')
 const { markDelivered, markRead, markAllRead, STATUS } = require('./status')
+const { trackPresence, setPresence, getPresence, getRoomPresence, PRESENCE_STATUS } = require('./presence')
+const { createRateLimiter } = require('./rateLimit')
+const { rejoinRooms, getUserRooms } = require('./reconnect')
 
 module.exports = {
   init,
@@ -26,5 +29,13 @@ module.exports = {
   markDelivered,
   markRead,
   markAllRead,
-  STATUS
+  STATUS,
+  trackPresence,
+  setPresence,
+  getPresence,
+  getRoomPresence,
+  PRESENCE_STATUS,
+  createRateLimiter,
+  rejoinRooms,
+  getUserRooms
 }

--- a/src/presence.js
+++ b/src/presence.js
@@ -1,0 +1,77 @@
+const { getIO } = require('./server')
+const { getRoomParticipants } = require('./rooms')
+
+const presenceMap = new Map()
+
+const PRESENCE_STATUS = {
+  ONLINE: 'online',
+  AWAY: 'away',
+  OFFLINE: 'offline'
+}
+
+function trackPresence(socket, userId) {
+  if (!userId) throw new Error('[quick-socket] trackPresence() requires a userId as the second argument.')
+
+  socket._qs_userId = userId
+
+  if (!presenceMap.has(userId)) {
+    presenceMap.set(userId, {
+      status: PRESENCE_STATUS.ONLINE,
+      socketIds: new Set(),
+      lastSeen: null,
+      meta: {}
+    })
+  }
+
+  const user = presenceMap.get(userId)
+  const wasOffline = user.socketIds.size === 0
+  user.socketIds.add(socket.id)
+  user.status = PRESENCE_STATUS.ONLINE
+
+  if (wasOffline) {
+    getIO().emit('presence:change', { userId, status: PRESENCE_STATUS.ONLINE, lastSeen: null })
+  }
+
+  socket.on('disconnect', () => {
+    user.socketIds.delete(socket.id)
+    if (user.socketIds.size === 0) {
+      user.status = PRESENCE_STATUS.OFFLINE
+      user.lastSeen = new Date()
+      getIO().emit('presence:change', {
+        userId,
+        status: PRESENCE_STATUS.OFFLINE,
+        lastSeen: user.lastSeen
+      })
+    }
+  })
+}
+
+function setPresence(userId, status, meta = {}) {
+  if (!Object.values(PRESENCE_STATUS).includes(status)) throw new Error(
+    `[quick-socket] setPresence() invalid status "${status}". Use PRESENCE_STATUS.ONLINE, AWAY, or OFFLINE.`
+  )
+  if (!presenceMap.has(userId)) throw new Error(
+    `[quick-socket] setPresence() user "${userId}" is not tracked. Call trackPresence(socket, userId) first.`
+  )
+  const user = presenceMap.get(userId)
+  user.status = status
+  if (status === PRESENCE_STATUS.OFFLINE) user.lastSeen = new Date()
+  Object.assign(user.meta, meta)
+  getIO().emit('presence:change', { userId, status, lastSeen: user.lastSeen, meta: user.meta })
+}
+
+function getPresence(userId) {
+  const user = presenceMap.get(userId)
+  if (!user) return { status: PRESENCE_STATUS.OFFLINE, lastSeen: null, meta: {} }
+  return { status: user.status, lastSeen: user.lastSeen, meta: user.meta }
+}
+
+function getRoomPresence(roomId) {
+  const participants = getRoomParticipants(roomId)
+  return participants.reduce((acc, p) => {
+    if (p.userId) acc[p.userId] = getPresence(p.userId)
+    return acc
+  }, {})
+}
+
+module.exports = { trackPresence, setPresence, getPresence, getRoomPresence, PRESENCE_STATUS }

--- a/src/rateLimit.js
+++ b/src/rateLimit.js
@@ -1,0 +1,49 @@
+const rateLimitMap = new Map()
+
+function createRateLimiter(options = {}) {
+  const limit = options.limit || 10
+  const windowMs = options.windowMs || 1000
+  const events = options.events || null
+  const onLimitReached = options.onLimitReached || null
+
+  return function rateLimitMiddleware(socket, next) {
+    rateLimitMap.set(socket.id, { count: 0, windowStart: Date.now() })
+
+    socket.use((packet, next) => {
+      const event = packet[0]
+      if (events && !events.includes(event)) return next()
+
+      const state = rateLimitMap.get(socket.id)
+      const now = Date.now()
+
+      if (now - state.windowStart > windowMs) {
+        state.count = 0
+        state.windowStart = now
+      }
+
+      state.count++
+
+      if (state.count > limit) {
+        if (onLimitReached) {
+          onLimitReached(socket, packet)
+        } else {
+          socket.emit('rateLimit:exceeded', {
+            event,
+            limit,
+            windowMs,
+            retryAfter: Math.ceil((state.windowStart + windowMs - now) / 1000)
+          })
+        }
+        return
+      }
+
+      next()
+    })
+
+    socket.on('disconnect', () => rateLimitMap.delete(socket.id))
+
+    next()
+  }
+}
+
+module.exports = { createRateLimiter }

--- a/src/reconnect.js
+++ b/src/reconnect.js
@@ -1,0 +1,49 @@
+const { getRoomMessages } = require('./messages')
+
+const userRoomsMap = new Map()
+
+function trackUserRoom(userId, roomId) {
+  if (!userId) return
+  if (!userRoomsMap.has(userId)) userRoomsMap.set(userId, new Set())
+  userRoomsMap.get(userId).add(roomId)
+}
+
+function untrackUserRoom(userId, roomId) {
+  if (!userId) return
+  userRoomsMap.get(userId)?.delete(roomId)
+}
+
+function clearRoomFromAllUsers(roomId) {
+  for (const roomIds of userRoomsMap.values()) {
+    roomIds.delete(roomId)
+  }
+}
+
+function rejoinRooms(socket, userId, options = {}) {
+  if (!userId) throw new Error('[quick-socket] rejoinRooms() requires a userId as the second argument.')
+
+  const roomIds = userRoomsMap.get(userId)
+  if (!roomIds || roomIds.size === 0) return { rooms: [], missedMessages: {} }
+
+  const rooms = []
+  const missedMessages = {}
+
+  for (const roomId of roomIds) {
+    socket.join(roomId)
+    rooms.push(roomId)
+
+    if (options.since) {
+      const since = new Date(options.since)
+      const { messages } = getRoomMessages(roomId, 1, 100)
+      missedMessages[roomId] = messages.filter(m => new Date(m.createdAt) > since)
+    }
+  }
+
+  return { rooms, missedMessages }
+}
+
+function getUserRooms(userId) {
+  return [...(userRoomsMap.get(userId) || [])]
+}
+
+module.exports = { trackUserRoom, untrackUserRoom, clearRoomFromAllUsers, rejoinRooms, getUserRooms }

--- a/src/rooms.js
+++ b/src/rooms.js
@@ -1,5 +1,6 @@
 const { getIO } = require('./server')
 const { clearRoomMessages } = require('./messages')
+const { trackUserRoom, untrackUserRoom, clearRoomFromAllUsers } = require('./reconnect')
 
 const rooms = new Map()
 
@@ -29,6 +30,7 @@ function joinRoom(socket, roomId, userMeta = {}) {
     '[quick-socket] joinRoom() requires a roomId as the second argument.'
   )
   socket.join(roomId)
+  trackUserRoom(userMeta.userId, roomId)
   const room = rooms.get(roomId)
   if (room) {
     room.participants.push({
@@ -54,6 +56,7 @@ function leaveRoom(socket, roomId) {
     const participant = room.participants.find(p => p.socketId === socket.id)
     userId = participant?.userId
     room.participants = room.participants.filter(p => p.socketId !== socket.id)
+    untrackUserRoom(userId, roomId)
   } else {
     console.warn(
       `[quick-socket] leaveRoom warning: room "${roomId}" does not exist in the rooms registry. ` +
@@ -71,6 +74,7 @@ function getRoomParticipants(roomId) {
 function closeRoom(roomId) {
   getIO().to(roomId).emit('room:closed', { roomId })
   clearRoomMessages(roomId)
+  clearRoomFromAllUsers(roomId)
   rooms.delete(roomId)
 }
 

--- a/src/server.js
+++ b/src/server.js
@@ -7,7 +7,9 @@ function init(httpServer, options = {}) {
     cors: {
       origin: options.cors || '*',
       methods: ['GET', 'POST']
-    }
+    },
+    pingInterval: options.pingInterval || 25000,
+    pingTimeout: options.pingTimeout || 20000
   })
 
   io.on('connection', (socket) => {


### PR DESCRIPTION
## Summary

- **Presence system** — track online/offline/away per user with `trackPresence()`, `setPresence()`, `getPresence()`, `getRoomPresence()`. Emits `presence:change` to all clients automatically on connect/disconnect.
- **Rate limiting** — per-socket sliding window via `createRateLimiter({ limit, windowMs })`. Attaches as a Socket.io middleware. Emits `rateLimit:exceeded` with `retryAfter` to the client on breach.
- **Reconnect recovery** — `rejoinRooms(socket, userId, { since })` re-attaches a reconnected user to all their previous rooms and returns missed messages since a given timestamp.
- **Heartbeat config** — `pingInterval` and `pingTimeout` now exposed through `init()` options.
- TypeScript types updated for all new APIs.

## Test plan

- [ ] Call `trackPresence(socket, userId)` in connection handler — verify `presence:change` fires on connect and disconnect
- [ ] Attach `createRateLimiter({ limit: 3, windowMs: 1000 })` via `io.use()` — verify 4th message in 1s is blocked and `rateLimit:exceeded` is received
- [ ] Disconnect a client, reconnect with same userId — verify `rejoinRooms` re-joins rooms and returns messages sent during disconnection
- [ ] Pass `pingInterval` / `pingTimeout` to `init()` — verify Socket.io server respects the values