### PR TITLE
fix: improve auth and delete message errors

### DIFF
--- a/src/messages.js
+++ b/src/messages.js
@@ -72,7 +72,17 @@ function editMessage(roomId, messageId, newContent) {
 }
 
 function deleteMessage(roomId, messageId) {
+  if (!roomId) throw new Error(
+    '[quick-socket] deleteMessage() requires a roomId as the first argument.'
+  )
+  if (!messageId) throw new Error(
+    '[quick-socket] deleteMessage() requires a messageId as the second argument.'
+  )
   const messages = roomMessages.get(roomId) || []
+  const messageExists = messages.some(msg => msg.id === messageId)
+  if (!messageExists) throw new Error(
+    `[quick-socket] deleteMessage() could not find message "${messageId}" in room "${roomId}".`
+  )
   roomMessages.set(roomId, messages.filter(msg => msg.id !== messageId))
   getIO().to(roomId).emit('message:deleted', {
     messageId,

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,13 +1,17 @@
 function authMiddleware(authFn) {
   return async (socket, next) => {
     const token = socket.handshake.auth?.token
-    if (!token) return next(new Error('No token provided'))
+    if (!token) return next(new Error(
+      '[quick-socket] Authentication failed: no token found. Pass a token in socket.handshake.auth.token.'
+    ))
     try {
       const user = await authFn(token)
       socket.user = user
       next()
     } catch (err) {
-      next(new Error('Authentication failed'))
+      next(new Error(
+        '[quick-socket] Authentication failed: the authFn you provided threw an error.'
+      ))
     }
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -114,14 +114,6 @@ async function runTests() {
   })
   log('editMessage delivers edited event', editResult?.content === 'Updated!')
 
-  // ── Test 9: deleteMessage ──
-  const deleteResult = await new Promise((resolve) => {
-    client2.once('message:deleted', (data) => resolve(data))
-    quickSocket.deleteMessage('room-1', 'msg-001')
-    setTimeout(() => resolve(null), 2000)
-  })
-  log('deleteMessage delivers deleted event', deleteResult?.messageId === 'msg-001')
-
   // ── Test 10: markDelivered ──
   const deliveredResult = await new Promise((resolve) => {
     client2.once('message:delivered', (data) => resolve(data))
@@ -164,7 +156,15 @@ async function runTests() {
   const pageTwo = quickSocket.getRoomMessages('room-1', 2, 2)
   log('getRoomMessages page 2 returns older messages', pageTwo.messages.length === 1 && pageTwo.messages[0]?.content === 'Updated!')
 
-  // ── Test 13: closeRoom ──
+  // ── Test 13: deleteMessage ──
+  const deleteResult = await new Promise((resolve) => {
+    client2.once('message:deleted', (data) => resolve(data))
+    quickSocket.deleteMessage('room-1', msgResult.id)
+    setTimeout(() => resolve(null), 2000)
+  })
+  log('deleteMessage delivers deleted event', deleteResult?.messageId === msgResult.id)
+
+  // ── Test 14: closeRoom ──
   const closeResult = await new Promise((resolve) => {
     client2.once('room:closed', (data) => resolve(data))
     quickSocket.closeRoom('room-1')
@@ -197,6 +197,13 @@ async function runTests() {
     validationPassed = false
   } catch (err) {
     if (!err.message.includes('non-empty string roomId')) validationPassed = false
+  }
+
+  try {
+    quickSocket.deleteMessage('room-1', 'missing-message')
+    validationPassed = false
+  } catch (err) {
+    if (!err.message.includes('could not find message')) validationPassed = false
   }
 
   log('validation throws correct errors for invalid inputs', validationPassed)


### PR DESCRIPTION
## Summary\n- make auth middleware failures explain whether a token is missing or the verifier failed\n- make deleteMessage validate room/message IDs and report missing messages clearly\n- update tests to cover the clearer error contracts\n\nAddresses #1\n\n## Test Report\n- `npm test`